### PR TITLE
Created a seperate library file for local model access, created a new…

### DIFF
--- a/src/components/message-item.vue
+++ b/src/components/message-item.vue
@@ -2,7 +2,7 @@
 <!-- eslint-disable no-empty -->
 <script setup>
 import { wrapCodeSnippets, showToast } from '@/libs/utils';
-import { Atom, SquareUser } from 'lucide-vue-next';
+import { Atom } from 'lucide-vue-next';
 
 // Props
 const props = defineProps({

--- a/src/libs/local-model-access.js
+++ b/src/libs/local-model-access.js
@@ -1,0 +1,105 @@
+/* eslint-disable no-unused-vars */
+import { showToast, sleep } from "./utils";
+
+let localStreamRetryCount = 0;
+export async function fetchLocalModelResponseStream(conversation, attitude, model, localModelEndpoint, updateUiFunction) {
+    const gptMessagesOnly = filterLocalMessages(conversation);
+
+    const requestOptions = {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Bearer lm-studio`,
+        },
+        body: JSON.stringify({
+            model: model,
+            stream: true,
+            messages: gptMessagesOnly,
+            temperature: attitude * 0.01
+        }),
+    };
+
+    try {
+        const response = await fetch(localModelEndpoint + `/v1/chat/completions`, requestOptions);
+
+        const result = await readResponseStream(response, updateUiFunction);
+
+        localStreamRetryCount = 0;
+        return result;
+    } catch (error) {
+        console.error("Error fetching Local Model response:", error);
+        localStreamRetryCount++
+
+        if (localStreamRetryCount < 3) {
+            await sleep(1500);
+            return fetchLocalModelResponseStream(conversation, attitude, model, localModelEndpoint, updateUiFunction);
+        }
+
+        return "Error fetching response from Local LLM Model";
+
+    }
+}
+
+async function readResponseStream(response, updateUiFunction) {
+    let decodedResult = "";
+
+    const reader = await response.body.getReader();
+    const decoder = new TextDecoder("utf-8");
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+            return decodedResult
+        };
+        const chunk = decoder.decode(value);
+        const parsedLines = parseLmStudioResponseChunk(chunk);
+        for (const parsedLine of parsedLines) {
+            const { choices } = parsedLine;
+            const { delta } = choices[0];
+            const { content } = delta;
+            if (content) {
+                decodedResult += content;
+                updateUiFunction(content);
+            }
+        }
+    }
+}
+
+let buffer = "";  // Buffer to hold incomplete JSON data across chunks
+function parseLmStudioResponseChunk(chunk) {
+    buffer += chunk;  // Append new chunk to buffer
+
+    // Handle the [DONE] tag
+    buffer = buffer.replace(/\[DONE\]/g, '');
+
+    const lines = buffer.split("\n");
+    const completeLines = lines.slice(0, -1);  // All lines except the last one
+    buffer = lines[lines.length - 1];  // Last line might be incomplete, keep it in buffer
+
+    const results = [];
+    for (const line of completeLines) {
+        let cleanedLine = line.trim();
+
+        const firstBraceIndex = cleanedLine.indexOf('{');
+        cleanedLine = firstBraceIndex !== -1 ? cleanedLine.substring(firstBraceIndex) : cleanedLine;
+
+        if (cleanedLine !== "") {
+            try {
+                const parsed = JSON.parse(cleanedLine);
+                results.push(parsed);
+            } catch (error) {
+                console.error("Failed to parse JSON:", cleanedLine, error);
+            }
+        }
+    }
+    return results;
+}
+
+function filterLocalMessages(conversation) {
+    let lastMessageContent = "";
+    return conversation.filter(message => {
+        const isGPT = !message.content.trim().toLowerCase().startsWith("image::") &&
+            !lastMessageContent.startsWith("image::");
+        lastMessageContent = message.content.trim().toLowerCase();
+        return isGPT;
+    });
+}

--- a/src/views/ChatLayout.vue
+++ b/src/views/ChatLayout.vue
@@ -2,10 +2,11 @@
 
 <script setup>
 import { ref, onMounted, computed, watch } from 'vue';
-import { loadConversationTitles, loadStoredConversations, fetchGPTResponseStream, fetchLocalModelResponseStream, generateDALLEImage } from '@/libs/gpt-api-access';
+import { loadConversationTitles, loadStoredConversations, fetchGPTResponseStream, generateDALLEImage } from '@/libs/gpt-api-access';
 import { fetchClaudeConversationTitle, streamClaudeResponse } from '@/libs/claude-api-access';
 import { getConversationTitleFromGPT, showToast } from '@/libs/utils';
 import { analyzeImage } from '@/libs/image-analysis';
+import { fetchLocalModelResponseStream } from '@/libs/local-model-access';
 
 import messageItem from '@/components/message-item.vue';
 import chatInput from '@/components/chat-input.vue';


### PR DESCRIPTION
Created new `local-model-access.js` lib and removed the Local Model api logic from the `gpt-api-access.js` lib and put it inside the new library.

Created new chunk parsing function in the local model lib as the responses are different between OpenAi and LM Studio for some reason.

Fixes issue with partial message cutoffs and console errors.

Updated local endpoint setting to not require users to input the trailing "v1/chat/completions" and instead only need to enter their local api IP and port number.

Solves #46 